### PR TITLE
virtscenario: Add SEV feature detection

### DIFF
--- a/src/virtscenario/features.py
+++ b/src/virtscenario/features.py
@@ -88,14 +88,11 @@ class Features():
         self.features = c.BasicConfiguration.features(self, datafeatures)
         return self.features
 
-    def security(self):
+    def security(self, sev_info):
         """
         security
         """
-        secdata = "<cbitpos>47</cbitpos>\n"
-        secdata += "    <reducedPhysBits>1</reducedPhysBits>\n"
-        secdata += "    <policy>0x0033</policy>"
-        self.security = c.BasicConfiguration.security(self, "sev", secdata)
+        self.security = c.BasicConfiguration.security(self, "sev", sev_info.get_xml())
         return self.security
 
     def memory_perf(self):

--- a/src/virtscenario/main.py
+++ b/src/virtscenario/main.py
@@ -30,6 +30,7 @@ import virtscenario.immutable as immut
 import virtscenario.qemulist as qemulist
 import virtscenario.xmlutil as xmlutil
 import virtscenario.host as host
+import virtscenario.sev as sev
 
 def create_default_domain_xml(xmlfile):
     """
@@ -669,9 +670,13 @@ class MyPrompt(Cmd):
         """
         if self.check_conffile() is not False:
             self.basic_config()
+
+            # SEV information
+            sev_info = host.sev_info()
+
             # BasicConfiguration
             scenario = s.Scenarios()
-            securevm = scenario.secure_vm()
+            securevm = scenario.secure_vm(sev_info)
             # Check user setting
             self.check_user_settings(securevm)
 
@@ -713,7 +718,7 @@ class MyPrompt(Cmd):
                 # Create the Virtual Disk image
                 host.create_storage_image(self.STORAGE_DATA)
                 # Prepare the host system
-                host.kvm_amd_sev()
+                host.kvm_amd_sev(sev_info)
                 host.manage_ksm("disable", "")
                 host.swappiness("0")
                 # mq-deadline / kyber / bfq / none

--- a/src/virtscenario/scenario.py
+++ b/src/virtscenario/scenario.py
@@ -122,7 +122,7 @@ class Scenarios():
         self.name = c.BasicConfiguration.name(self, "easy_migration")
         return self
 
-    def secure_vm(self):
+    def secure_vm(self, sev_info):
         """
         secure VM
         """
@@ -148,7 +148,7 @@ class Scenarios():
         # Set some expected features
         f.Features.features_perf(self)
         f.Features.clock_perf(self)
-        f.Features.security(self)
+        f.Features.security(self, sev_info)
         return self
 
     def soft_rt_vm(self):

--- a/src/virtscenario/sev.py
+++ b/src/virtscenario/sev.py
@@ -1,0 +1,139 @@
+# Authors: Joerg Roedel <jroedel@suse.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+SEV Feature Detection
+"""
+
+from string import Template
+import xml.etree.ElementTree as ET
+import virtscenario.template as template
+import virtscenario.util as util
+
+"""
+SEV Policy bits
+"""
+# Disable debug support
+SEV_POLICY_NODBG    = 0x01
+# Disable key sharing with other domains
+SEV_POLICY_NOKS     = 0x02
+# Enable encrypted state
+SEV_POLICY_ES       = 0x04
+# Migration via PSP is disallowed
+SEV_POLICY_NOSEND   = 0x08
+# The guest must not be transmitted to another platform that is not in the domain when set.
+SEV_POLICY_DOMAIN   = 0x10
+# The guest must not be transmitted to another platform that is not SEV capable when set.
+SEV_POLICY_SEV      = 0x20
+
+class SevNotSupported(BaseException):
+    def __init(__self__):
+        pass
+
+class SevInfo:
+    """
+    AMD Secure Encrypted Virtualization (SEV) host feature detection
+    This class is used to detect SEV host features like the CBIT position and
+    SEV-ES availability.
+    """
+    def __init__(self):
+        """
+        Member initialization
+        """
+        self.sev_supported = False
+        self.sev_es_supported = False
+        self.sev_cbitpos = None
+        self.sev_reduced_phys_bits = None
+
+    def supported(self):
+        return self.sev_supported
+
+    def host_detect(self):
+        """
+        Detect SEV features from the 'virsh domcapabilities' XML outout
+        """
+
+        try:
+            xmldata, errs = util.system_command("virsh domcapabilities")
+            if errs:
+                print(errs)
+                return
+            root = ET.fromstring(xmldata)
+            feature_list = root.findall("./features/sev[@supported='yes']")
+            if len(feature_list) == 0:
+                raise SevNotSupported()
+
+            # SEV is supported on this machine
+            self.sev_supported = True
+
+            # Now check capabilites of SEV
+            sev_features = feature_list[0]
+
+            # Search for SEV-ES support
+            max_es_guests = sev_features.findall("./maxESGuests")
+            if len(max_es_guests) > 0:
+                # libVirt claims SEV-ES support - check maximum number of guests is > 0
+                es_guests = max_es_guests[0]
+                num_guests = int(es_guests.text)
+                if num_guests > 0:
+                    self.sev_es_supported = True
+
+            # Get C-Bit Position
+            cbitpos_list = sev_features.findall("./cbitpos")
+            if len(cbitpos_list) == 0:
+                raise SevNotSupported
+
+            cbitpos = cbitpos_list[0]
+            self.sev_cbitpos = cbitpos.text
+
+            # Get reducedPhysBits
+            reduced_list = sev_features.findall("./reducedPhysBits")
+            if len(reduced_list) == 0:
+                raise SevNotSupported
+
+            reduced_phys_bits = reduced_list[0]
+            self.sev_reduced_phys_bits = reduced_phys_bits.text
+
+        except SevNotSupported:
+            self.sev_supported = False
+            self.sev_es_supported = False
+            self.cbitpos = None
+            self.reduced_phys_bits = None
+            return False
+
+        return True
+
+    def get_xml(self):
+        """
+        Generate libVirt XML specification for SEV
+        """
+        if self.sev_supported == False:
+            return '';
+
+        policy = SEV_POLICY_NODBG + SEV_POLICY_NOKS + SEV_POLICY_DOMAIN + SEV_POLICY_SEV
+
+        # Enable SEV-ES when supported
+        if self.sev_es_supported:
+            policy += SEV_POLICY_ES
+
+        # Generate XML
+        xml_template = template.SEV_TEMPLATE;
+        xml_sev_data = {
+            'cbitpos': self.sev_cbitpos,
+            'reducedphysbits': self.sev_reduced_phys_bits,
+            'policy': hex(policy),
+        }
+
+        return Template(xml_template).substitute(xml_sev_data)

--- a/src/virtscenario/template.py
+++ b/src/virtscenario/template.py
@@ -212,6 +212,10 @@ SECURITY_TEMPLATE = """
     ${secdata}
   </launchSecurity>"""
 
+SEV_TEMPLATE = """<cbitpos>${cbitpos}</cbitpos>
+    <reducedPhysBits>${reducedphysbits}</reducedPhysBits>
+    <policy>${policy}</policy>"""
+
 CONTROLLER_SATA = """
     <controller type="sata" index="0">
       <address type="pci" domain="0x0000" bus="0x00" slot="0x1f" function="0x2"/>


### PR DESCRIPTION
Add a new class SevInfo which calls into libvirt to detect SEV and SEV-ES support. Also auto-detect these required configuration parameters:

	* C-Bit position
	* Reduced physical address bits

Also generate a default policy for the guest depending on the supported SEV features.

Make use of the detected information in the check_libvirt_sev() function and when generating the guest XML configuration.

Signed-off-by: Joerg Roedel <jroedel@suse.de>