### PR TITLE
Fix FileNotFound error when calling 'virt-scenario-launch --list' (bsc#1216383)

### DIFF
--- a/src/virtscenario_launch/main.py
+++ b/src/virtscenario_launch/main.py
@@ -58,6 +58,8 @@ class VMConfigs:
                         for k2, v2 in subitem.items():
                             if k2 == 'vm-config-store':
                                 self.base_path = os.path.expanduser(v2)
+        if not os.path.isdir(self.base_path):
+            self.base_path = configuration.find_vmconfig_dir()
 
     def list_vms(self):
         vm_array = []


### PR DESCRIPTION
 - We first read the value of `vm-config-store` in `virtscenario.yaml`, if the config-defined location doesn't exist we fallback to finding the directory with `find_vmconfig_dir()`

 - It isn't clear if we even need 'vm-config-store' to be configurable. The logic could be simplified if it wasn't user configurable
 
 - Past this issue, it appeared that `virt-scenario-launch --start <vm>` was hardcoding the network name to be "default", but after creating a network named "default", creating and starting a VM was sucessful with the following commands:
   - `virt-scenario desktop`
   - `virt-scenario-launch --list`
   - `virt-scenario-launch --start desktop`

 - This was tested against the latest kvm-server and kvm-client containers
   - https://build.opensuse.org/request/show/1119753
   - https://build.opensuse.org/request/show/1119754